### PR TITLE
Export data to CSV

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             <version>4.1.2</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>java-lib</artifactId>
             <version>4.37</version>

--- a/src/main/java/com/wavefront/tools/wftop/WavefrontTop.java
+++ b/src/main/java/com/wavefront/tools/wftop/WavefrontTop.java
@@ -2,6 +2,8 @@ package com.wavefront.tools.wftop;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
@@ -20,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -30,11 +33,12 @@ public class WavefrontTop {
   private static final Logger log = Logger.getLogger("wftop");
 
   private final Timer timer = new Timer(true);
-
+  private final Stopwatch stopwatch = Stopwatch.createUnstarted();
   private final ClusterConfigurationPanel clusterConfigurationPanel = new ClusterConfigurationPanel();
   private final PointsSpy pointsSpy = new PointsSpy();
   private final AtomicInteger backendCount = new AtomicInteger(0);
   private final List<Node> breadCrumbs = new ArrayList<>();
+
   /**
    * What are we analyzing (metric names? hosts? point tags?)
    */
@@ -49,6 +53,7 @@ public class WavefrontTop {
   private NamespacePanel namespacePanel;
   private AtomicBoolean exit;
   private BasicWindow pointsSpyWindow;
+  private Screen screen;
 
   @Parameter(names = "--log", description = "Log to console")
   private boolean logToConsole = false;
@@ -64,10 +69,66 @@ public class WavefrontTop {
   @Parameter(names = "--cluster", description = "Wavefront Cluster (metrics.wavefront.com)")
   private String cluster = null;
 
+  @Parameter(names = {"-h", "--help"}, description = "Display flag options", help = true)
+  private boolean help = false;
+
+  @Nullable
+  @Parameter(names = "--export", description = "Export wftop data. " +
+      "Specify with output (-f)ile and (-t)ime in seconds")
+  private boolean exportData = false;
+
+  /**
+   * Export data flags to set Point Spy.
+   */
+  @Parameter(names = {"-spy", "-spy-on"}, description = "Spy on point or Id Creations")
+  private String spyOnArg = "POINT";
+
+  @Parameter(names = {"-dim", "-dimension"}, description = "Analysis dimension or Id type")
+  private String dimenArg = "METRIC";
+
+  @Parameter(names = {"-g", "-group"}, description = "Group By")
+  private boolean groupByArg = false;
+
+  @Parameter(names = {"-r", "-rate"}, description = "Sample rate")
+  private double rateArg = 0.01;
+
+  @Parameter(names = {"-sep", "-separators"}, description = "Separators")
+  private String separatorsArg = ".-_=";
+
+  @Parameter(names = "-days", description = "Usage lookback days")
+  private int usageDaysArg = 7;
+
+  @Parameter(names = {"-dep", "-depth"}, description = "Maximum depth")
+  private int depthArg = 10;
+
+  @Parameter(names = {"-c", "-children"}, description = "Maximum child per node")
+  private int maxChildrenArg = 1000;
+
+  @Nullable
+  @Parameter(names = {"-f", "-file"}, description = "File to save exported data. " +
+      "Specify with --export and (-t)ime in seconds")
+  private String exportFile = null;
+
+  @Parameter(names = {"-t", "-time", "-time-in-seconds"}, description = "Export timer in seconds." +
+      " Specify with --export and output (-f)ile")
+  private long exportTime = 0;
+
   public static void main(String[] args) {
     WavefrontTop wavefrontTop = new WavefrontTop();
-    JCommander.newBuilder().addObject(wavefrontTop).build().parse(args);
-    wavefrontTop.run();
+    JCommander jCommander = JCommander.newBuilder().addObject(wavefrontTop).build();
+    try {
+      jCommander.parse(args);
+      wavefrontTop.validateArgs();
+      if (wavefrontTop.help) {
+        jCommander.usage();
+        System.exit(0);
+      }
+      wavefrontTop.run();
+    } catch (ParameterException pe) {
+      System.out.println("ParameterException: " + pe.getMessage());
+      System.out.println("Run ./target/wftop with -h or --help to view flag options");
+      System.exit(1);
+    }
   }
 
   private void run() {
@@ -77,8 +138,9 @@ public class WavefrontTop {
       globalLogger.setLevel(java.util.logging.Level.OFF);
     }
     DefaultTerminalFactory defaultTerminalFactory = new DefaultTerminalFactory();
-    Screen screen = null;
+    screen = null;
     try {
+      //start Timer to keep track of running; does not stop on disconnect
       Terminal terminal = emulator ? defaultTerminalFactory.createTerminalEmulator() :
           defaultTerminalFactory.createTerminal();
       screen = new TerminalScreen(terminal);
@@ -86,94 +148,33 @@ public class WavefrontTop {
       screen.setCursorPosition(null);
       // Create gui and start gui
       MultiWindowTextGUI gui =
-        new MultiWindowTextGUI(screen, new DefaultWindowManager(),
-        new EmptySpace(TextColor.ANSI.BLACK));
+          new MultiWindowTextGUI(screen, new DefaultWindowManager(),
+              new EmptySpace(TextColor.ANSI.BLACK));
       SpyConfigurationPanel spyConfigurationPanel = new SpyConfigurationPanel(gui);
       PointsNamespacePanel pointsNamespacePanel = new PointsNamespacePanel(spyConfigurationPanel, gui);
       IdNamespacePanel idNamespacePanel = new IdNamespacePanel(spyConfigurationPanel, gui);
-      namespacePanel = pointsNamespacePanel;
+      this.spyOnPoint = spyOnArg.equals("POINT");
+      namespacePanel = (spyOnPoint) ? pointsNamespacePanel : idNamespacePanel;
+      namespacePanel.setExportData(exportData, exportFile);
 
-      //default SPY on data points, can SPY on newly created IDs
-      spyConfigurationPanel.setSamplingRate(pointsSpy.getSamplingRate());
-      spyConfigurationPanel.setUsageDaysThreshold(pointsSpy.getUsageDaysThreshold());
+      root.setSeparatorCharacters(separatorsArg);
+      root.setMaxDepth(depthArg);
+      root.setMaxChildren(maxChildrenArg);
+      groupByIngestionSource = spyOnPoint && groupByArg;
+      if (spyOnPoint) analysisDimension = getPointDimension(dimenArg);
+      setSpyConfigurationPanel(spyConfigurationPanel, pointsNamespacePanel, idNamespacePanel);
 
-      spyConfigurationPanel.setSeparatorCharacters(root.getSeparatorCharacters());
-      spyConfigurationPanel.setMaxDepth(root.getMaxDepth());
-      spyConfigurationPanel.setMaxChildren(root.getMaxChildren());
-
-      spyConfigurationPanel.startParameters(this.spyOnPoint);
-      spyConfigurationPanel.setListener(panel -> {
-        this.spyOnPoint = panel.getSpyOnPoint();
-        pointsSpy.setSpyOn(panel.getSpyOnPoint());
-        pointsSpy.setSamplingRate(panel.getSamplingRate());
-        pointsSpy.setUsageDaysThreshold(panel.getUsageThresholdDays());
-
-        root.setSeparatorCharacters(panel.getSeparatorCharacters());
-        root.setMaxDepth(panel.getMaxDepth());
-        root.setMaxChildren(panel.getMaxChildren());
-
-        if (spyOnPoint) {
-          analysisDimension = panel.getDimension();
-          groupByIngestionSource = panel.getIngestionSource();
-        } else {
-          groupByIngestionSource = false;
-          IDType = panel.getType();
-          pointsSpy.setTypePrefix(IDType);
-        }
-        pointsSpy.start();
-        reset();
-        namespacePanel = (spyOnPoint) ? pointsNamespacePanel : idNamespacePanel;
-        setNamespacePanel(exit, pointsSpyWindow);
-      });
-      pointsSpy.setListener(new PointsSpy.Listener() {
-        @Override
-        public void onBackendCountChanges(PointsSpy pointsSpy, int numBackends) {
-          backendCount.set(numBackends);
-          reset();
-        }
-
-        @Override
-        public void onIdReceived(PointsSpy pointsSpy, Type type, String name) {
-          root.accept(name);
-        }
-
-        @Override
-        public void onMetricReceived(PointsSpy pointsSpy, boolean accessed, String metric, String host,
-                                     Multimap<String, String> pointTags, long timestamp, double value) {
-          root.accept(analysisDimension, groupByIngestionSource, accessed, metric, host,
-            pointTags, timestamp, value);
-        }
-
-        @Override
-        public void onConnectivityChanged(PointsSpy pointsSpy, boolean connected,
-                                          @Nullable String message) {
-          if (connected) {
-            namespacePanel.setConnected();
-          } else {
-            namespacePanel.setConnectionError(message);
-          }
-        }
-
-        @Override
-        public void onConnecting(PointsSpy pointsSpy) {
-          namespacePanel.setConnecting();
-        }
-      });
       if (token != null && cluster != null) {
         clusterConfigurationPanel.set(cluster, token);
       } else {
         if (collectClusterConfiguration(gui)) return;
       }
-      if (spyOnPoint) {
-        pointsSpy.setParameters(clusterConfigurationPanel.getClusterUrl(),
-            clusterConfigurationPanel.getToken(), null, null, null,
-            0.01, 7);
-      } else {
-        pointsSpy.setParameters(clusterConfigurationPanel.getClusterUrl(),
-            clusterConfigurationPanel.getToken(), null, null, 1);
-      }
+
+      setPointsSpy(clusterConfigurationPanel);
       pointsSpy.start();
+      stopwatch.start();
       breadCrumbs.add(root);
+      if (!groupByIngestionSource) breadCrumbs.add(root.getDefaultRoot());
       // begin spying.
       if (spyPoints(gui)) return;
     } catch (Throwable t) {
@@ -210,6 +211,7 @@ public class WavefrontTop {
       public void run() {
         double samplingRate = pointsSpy.getSamplingRate();
         namespacePanel.setGlobalPPS(Math.max(1, backendCount.get()) / samplingRate, root.getRate());
+        namespacePanel.setStopwatchTime(stopwatch.elapsed(TimeUnit.SECONDS));
         namespacePanel.setSamplingRate(samplingRate);
         namespacePanel.setVisibleRows(gui.getScreen().getTerminalSize().getRows() - 10);
         if (pointsSpy.isConnected()) {
@@ -222,8 +224,19 @@ public class WavefrontTop {
   private void refreshNamespacePanel(double samplingRate) {
     if (breadCrumbs.size() >= 1) {
       Node node = breadCrumbs.get(breadCrumbs.size() - 1);
+      if (exportData && stopwatch.elapsed(TimeUnit.SECONDS) == exportTime) {
+        namespacePanel.renderNodes(node, Math.max(1, backendCount.get()) / samplingRate,
+            node.getNodes().values(), true);
+        try {
+          screen.close();
+        } catch (IOException e) {
+          e.printStackTrace();
+          System.exit(1);
+        }
+        System.exit(0);
+      }
       namespacePanel.renderNodes(node, Math.max(1, backendCount.get()) / samplingRate,
-          node.getNodes().values());
+          node.getNodes().values(), false);
       computePath();
     }
   }
@@ -269,13 +282,104 @@ public class WavefrontTop {
     if (!lastKnownClusterConfig.exists() || lastKnownClusterConfig.canWrite()) {
       try {
         Files.write(
-          path,
-          ImmutableList.of(clusterConfigurationPanel.getClusterUrl(), clusterConfigurationPanel.getToken()));
+            path,
+            ImmutableList.of(clusterConfigurationPanel.getClusterUrl(), clusterConfigurationPanel.getToken()));
       } catch (IOException e) {
         log.log(Level.WARNING, "Cannot write .wftop_cluster", e);
       }
     }
     return false;
+  }
+
+  private void setPointsSpy(ClusterConfigurationPanel clusterConfigurationPanel) {
+    pointsSpy.setSpyOn(spyOnPoint);
+    pointsSpy.setSamplingRate(rateArg);
+    pointsSpy.setUsageDaysThreshold(usageDaysArg);
+
+    if (spyOnPoint) {
+      pointsSpy.setParameters(clusterConfigurationPanel.getClusterUrl(),
+          clusterConfigurationPanel.getToken(), null, null, null,
+          rateArg, usageDaysArg);
+    } else {
+      pointsSpy.setParameters(clusterConfigurationPanel.getClusterUrl(),
+          clusterConfigurationPanel.getToken(), null, null, rateArg);
+      IDType = getIDType(dimenArg);
+      pointsSpy.setTypePrefix(IDType);
+    }
+    pointsSpy.setListener(new PointsSpy.Listener() {
+      @Override
+      public void onBackendCountChanges(PointsSpy pointsSpy, int numBackends) {
+        backendCount.set(numBackends);
+        reset();
+      }
+
+      @Override
+      public void onIdReceived(PointsSpy pointsSpy, Type type, String name) {
+        root.accept(name);
+      }
+
+      @Override
+      public void onMetricReceived(PointsSpy pointsSpy, boolean accessed, String metric, String host,
+                                   Multimap<String, String> pointTags, long timestamp, double value) {
+        root.accept(analysisDimension, groupByIngestionSource, accessed, metric, host,
+            pointTags, timestamp, value);
+      }
+
+      @Override
+      public void onConnectivityChanged(PointsSpy pointsSpy, boolean connected,
+                                        @Nullable String message) {
+        if (connected) {
+          namespacePanel.setConnected();
+        } else {
+          namespacePanel.setConnectionError(message);
+        }
+      }
+
+      @Override
+      public void onConnecting(PointsSpy pointsSpy) {
+        namespacePanel.setConnecting();
+      }
+    });
+  }
+
+  private void setSpyConfigurationPanel(SpyConfigurationPanel spyConfigurationPanel,
+                                        PointsNamespacePanel pointsNamespacePanel,
+                                        IdNamespacePanel idNamespacePanel) {
+    spyConfigurationPanel.setSpyOn(spyOnPoint);
+    spyConfigurationPanel.setSpyDimension(spyOnPoint, dimenArg);
+
+    spyConfigurationPanel.setSamplingRate(rateArg);
+    spyConfigurationPanel.setUsageDaysThreshold(usageDaysArg);
+    spyConfigurationPanel.setGroupBy();
+
+    spyConfigurationPanel.setSeparatorCharacters(root.getSeparatorCharacters());
+    spyConfigurationPanel.setMaxDepth(root.getMaxDepth());
+    spyConfigurationPanel.setMaxChildren(root.getMaxChildren());
+
+    spyConfigurationPanel.startParameters(this.spyOnPoint);
+    spyConfigurationPanel.setListener(panel -> {
+      this.spyOnPoint = panel.getSpyOnPoint();
+      pointsSpy.setSpyOn(panel.getSpyOnPoint());
+      pointsSpy.setSamplingRate(panel.getSamplingRate());
+      pointsSpy.setUsageDaysThreshold(panel.getUsageThresholdDays());
+
+      root.setSeparatorCharacters(panel.getSeparatorCharacters());
+      root.setMaxDepth(panel.getMaxDepth());
+      root.setMaxChildren(panel.getMaxChildren());
+
+      if (spyOnPoint) {
+        analysisDimension = panel.getDimension();
+        groupByIngestionSource = panel.getIngestionSource();
+      } else {
+        groupByIngestionSource = false;
+        IDType = panel.getType();
+        pointsSpy.setTypePrefix(IDType);
+      }
+      pointsSpy.start();
+      reset();
+      namespacePanel = (spyOnPoint) ? pointsNamespacePanel : idNamespacePanel;
+      setNamespacePanel(exit, pointsSpyWindow);
+    });
   }
 
   private void setNamespacePanel(AtomicBoolean exit, BasicWindow pointsSpyWindow) {
@@ -306,7 +410,7 @@ public class WavefrontTop {
       @Override
       public void sortRight() {
         namespacePanel.setSortIndex(
-          Math.min(namespacePanel.getTableColumnCount() - 1, namespacePanel.getSortIndex() + 1));
+            Math.min(namespacePanel.getTableColumnCount() - 1, namespacePanel.getSortIndex() + 1));
         refreshNamespacePanel(pointsSpy.getSamplingRate());
       }
 
@@ -374,12 +478,126 @@ public class WavefrontTop {
       limited |= breadCrumbs.get(i).isLimited();
       if (i >= 2) path.append(breadCrumbs.get(i).getValue());
     }
+    namespacePanel.setRootPath(path.toString());
     if (limited) {
       path.append(" [EXPANSION HALTED (PER CONFIG)]");
     }
     if (backendCount.get() == 0) {
-      path.append(" [PPS and %ACCESSED IS NOT AVAILABLE/ACCURATE]");
+      path.append(" [" + ((spyOnPoint) ? "PPS and %ACCESSED" : "CPS") + " IS NOT AVAILABLE/ACCURATE]");
     }
     namespacePanel.setPath(path.toString(), limited || backendCount.get() == 0);
+  }
+
+  /**
+   * Validate flag values and combinations for spy and export.
+   */
+  private void validateArgs() {
+    //check spy configuration args
+    spyOnArg = spyOnArg.toUpperCase();
+    if (!(spyOnArg.equals("POINT") || (spyOnArg.equals("ID")))) {
+      throw new ParameterException("Spy On flag must be POINT or ID");
+    }
+    dimenArg = dimenArg.toUpperCase();
+    StringBuilder spyError = new StringBuilder();
+    if (spyOnArg.equals("POINT") && !(isPointDimension(dimenArg))) {
+      spyError.append("Point dimensions: [METRIC, HOST, POINT_TAG_KEY, POINT_TAG]");
+    } else if (spyOnArg.equals("ID") && !(isIDType(dimenArg))) {
+      spyError.append("ID types: [METRIC, HOST, POINT_TAG, HISTOGRAM, SPAN]");
+    }
+    if (spyError.length() > 0) {
+      throw new ParameterException("Cannot spy on given dimension, " + spyError);
+    }
+    if (spyOnArg.equals("POINT") && (rateArg < 0 || rateArg > 0.05)) {
+      throw new ParameterException("Invalid sample rate, must be > 0 and <= 0.05 for POINT");
+    } else if (spyOnArg.equals("ID") && (rateArg < 0 || rateArg > 1.0)) {
+      throw new ParameterException("Invalid sample rate, must be > 0 and <= 1 for ID");
+    }
+    if (usageDaysArg < 1 || usageDaysArg > 60) {
+      throw new ParameterException("Invalid usage days threshold, must be > 0 and <= 60");
+    }
+    if (depthArg < 1) {
+      throw new ParameterException("Invalid max depth, must be > 0");
+    }
+    if (maxChildrenArg < 1) {
+      throw new ParameterException("Invalid max children, must be > 0");
+    }
+
+    //check file and time given if exporting data
+    if (exportData) {
+      StringBuilder exportError = new StringBuilder();
+      if (exportFile == null) {
+        exportError.append("output file must be given");
+      } else if (!exportFile.endsWith(".csv")) {
+        exportFile = exportFile + ".csv";
+      }
+      if (exportTime == 0) {
+        exportError.append(((exportFile == null) ? " AND " : "") +
+            "length of timer in seconds must be given");
+      }
+      if (exportTime < 0) {
+        exportError.append("length of timer must be greater than 0 seconds");
+      }
+      if (exportError.length() > 0) {
+        throw new ParameterException("To export data, " + exportError.toString());
+      }
+    } else {
+      if (exportFile != null || exportTime != 0)
+        throw new ParameterException("--export flag must be set");
+    }
+  }
+
+  private boolean isPointDimension(String dimension) {
+    switch (dimension) {
+      case "METRIC":
+      case "HOST":
+      case "POINT_TAG_KEY":
+      case "POINT_TAG":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private boolean isIDType(String dimension) {
+    switch (dimension) {
+      case "HOST":
+      case "METRIC":
+      case "POINT_TAG":
+      case "HISTOGRAM":
+      case "SPAN":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private Dimension getPointDimension(String dimension) {
+    switch (dimension) {
+      case "HOST":
+        return Dimension.HOST;
+      case "POINT_TAG_KEY":
+        return Dimension.POINT_TAG_KEY;
+      case "POINT_TAG":
+        return Dimension.POINT_TAG;
+      case "METRIC":
+      default:
+        return Dimension.METRIC;
+    }
+  }
+
+  private Type getIDType(String type) {
+    switch (type) {
+      case "HOST":
+        return Type.HOST;
+      case "POINT_TAG":
+        return Type.POINT_TAG;
+      case "HISTOGRAM":
+        return Type.HISTOGRAM;
+      case "SPAN":
+        return Type.SPAN;
+      case "METRIC":
+      default:
+        return Type.METRIC;
+    }
   }
 }

--- a/src/main/java/com/wavefront/tools/wftop/components/PointsSpy.java
+++ b/src/main/java/com/wavefront/tools/wftop/components/PointsSpy.java
@@ -407,6 +407,20 @@ public class PointsSpy {
     }
   }
 
+  public Dimension getDimension(String dimension) {
+    switch (dimension) {
+      case "HOST" :
+        return Dimension.HOST;
+      case "POINT_TAG":
+        return Dimension.POINT_TAG;
+      case "POINT_TAG_KEY":
+        return Dimension.POINT_TAG_KEY;
+      case "METRIC":
+      default:
+        return Dimension.METRIC;
+    }
+  }
+
   /**
    * @param line Each line is Type, Id name, Id number.
    */
@@ -461,6 +475,10 @@ public class PointsSpy {
         this.typePrefix = "METRIC";
         break;
     }
+  }
+
+  public void setSpyOnPoint(boolean spyOnPoint) {
+    this.spyOnPoint = spyOnPoint;
   }
 
   public interface Listener {

--- a/src/main/java/com/wavefront/tools/wftop/components/RootNode.java
+++ b/src/main/java/com/wavefront/tools/wftop/components/RootNode.java
@@ -24,6 +24,7 @@ public class RootNode implements Node<SourceNode> {
 
   public RootNode(String value) {
     this.value = value;
+    reset();
   }
 
   @Override

--- a/src/main/java/com/wavefront/tools/wftop/panels/IdNamespacePanel.java
+++ b/src/main/java/com/wavefront/tools/wftop/panels/IdNamespacePanel.java
@@ -5,10 +5,14 @@ import com.codahale.metrics.Snapshot;
 import com.google.common.collect.Ordering;
 import com.googlecode.lanterna.gui2.MultiWindowTextGUI;
 import com.wavefront.tools.wftop.components.Node;
-import com.wavefront.tools.wftop.panels.NamespacePanel;
-import com.wavefront.tools.wftop.panels.SpyConfigurationPanel;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang.StringUtils;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -46,14 +50,17 @@ public class IdNamespacePanel extends NamespacePanel {
   }
 
   @Override
-  protected void addFirstRow(Node root, double factor, Collection<Node> nodes, Snapshot snapshot) {
+  protected void addFirstRow(Node root, double factor, Collection<Node> nodes, Snapshot snapshot,
+                             boolean takeSnapshot) {
     this.table.getTableModel().addRow("..", // artificial ".."
         (Math.round(factor * root.getRate().getOneMinuteRate()) + "cps"),
         String.valueOf(root.getEstimatedMetricCardinality()));
+    if (takeSnapshot) exportData(rootPath, root, factor);
   }
 
   @Override
-  protected void addNodes(Node root, double factor, Collection<Node> nodes, Snapshot snapshot, String selectedLabel) {
+  protected void addNodes(Node root, double factor, Collection<Node> nodes, Snapshot snapshot,
+                          String selectedLabel, boolean takeSnapshot) {
     Ordering<Node> ordering = Ordering.from(getComparator());
     if (reverseSort) ordering = ordering.reverse();
     List<Node> sorted = ordering.sortedCopy(nodes);
@@ -68,6 +75,7 @@ public class IdNamespacePanel extends NamespacePanel {
       table.getTableModel().addRow(flattened,
           (Math.round(factor * node.getRate().getOneMinuteRate()) + "cps"),
           String.valueOf(node.getEstimatedMetricCardinality()));
+      if (takeSnapshot) exportData(flattened, node, factor);
       num++;
       if (num > 1000) break;
     }
@@ -80,5 +88,27 @@ public class IdNamespacePanel extends NamespacePanel {
         Math.round(factor * rate.getOneMinuteRate()) + "cps | 5m " +
         Math.round(factor * rate.getFiveMinuteRate()) + "cps | 15m " +
         Math.round(factor * rate.getFifteenMinuteRate()) + "cps");
+  }
+
+  @Override
+  public void setUpCSVWriter() {
+    try {
+      BufferedWriter bufferedWriter = Files.newBufferedWriter(Paths.get(exportFile));
+      csvPrinter = new CSVPrinter(bufferedWriter, CSVFormat.DEFAULT.withHeader(
+          "Namespace", "CPS", "Num Metrics"));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void exportData(String namespace, Node node, double factor) {
+    try{
+      csvPrinter.printRecord(namespace,
+          Math.round(factor * node.getRate().getOneMinuteRate()) + "cps",
+          String.valueOf(node.getEstimatedMetricCardinality()));
+      csvPrinter.flush();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/src/main/java/com/wavefront/tools/wftop/panels/SpyConfigurationPanel.java
+++ b/src/main/java/com/wavefront/tools/wftop/panels/SpyConfigurationPanel.java
@@ -219,7 +219,7 @@ public class SpyConfigurationPanel extends BasicWindow {
 
     form.addComponent(typeLabel);
     form.addComponent(typeRadioBL);
-    setSamplingRate(1);
+    setSamplingRate(0.01);
     rateLabel.setText("Sampling Rate (0 < r <= 1): ");
   }
 
@@ -333,6 +333,40 @@ public class SpyConfigurationPanel extends BasicWindow {
     return ingestionRadioBL.getCheckedItem().equals("Wavefront Ingestion Source");
   }
 
+  public void setSpyOn(boolean spyOnPoint){
+    this.spyOnPoint = spyOnPoint;
+    this.spyRadioBL.setCheckedItemIndex((spyOnPoint) ? 0 : 1);
+  }
+
+  public void setSpyDimension(boolean spyOnPoint, String dimension){
+    //check spyOn type: if point; check if can set one of the analysis dimension
+    switch (dimension){
+      case "METRIC":
+        if (spyOnPoint) dimensionRadioBL.setCheckedItemIndex(0);
+        else typeRadioBL.setCheckedItemIndex(0);
+        break;
+      case "HOST":
+        if (spyOnPoint) dimensionRadioBL.setCheckedItemIndex(1);
+        else typeRadioBL.setCheckedItemIndex(1);
+        break;
+      case "POINT_TAG":
+        if (spyOnPoint) dimensionRadioBL.setCheckedItemIndex(2);
+        else typeRadioBL.setCheckedItemIndex(2);
+        break;
+      case "POINT_TAG_KEY":
+        dimensionRadioBL.setCheckedItemIndex(3);
+        break;
+      case "HISTOGRAM":
+        typeRadioBL.setCheckedItemIndex(3);
+        break;
+      case "SPAN":
+        typeRadioBL.setCheckedItemIndex(4);
+        default:
+          if (spyOnPoint) dimensionRadioBL.setCheckedItemIndex(0);
+          else typeRadioBL.setCheckedItemIndex(0);
+    }
+  }
+
   public void setSamplingRate(double rate) {
     this.samplingRateTB.setText(String.valueOf(rate));
   }
@@ -343,6 +377,10 @@ public class SpyConfigurationPanel extends BasicWindow {
 
   public void setUsageDaysThreshold(int days) {
     this.usageDaysThresholdTB.setText(String.valueOf(days));
+  }
+
+  public void setGroupBy() {
+    this.ingestionRadioBL.setCheckedItemIndex(1);
   }
 
   public void setMaxDepth(int depth) {


### PR DESCRIPTION
- Added Spy Configuration flags in command line (Choose to spy on point/id, group, set rate, separators etc with flags). Use --help for -h flag to see flag options.
-  Add export feature: Given time and file name, Wavefront Top runs for given number of seconds, and data currently displayed into a CSV file.